### PR TITLE
Updated the package name to `gana` and use go1.18 for syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/thecsw/echidna
+module github.com/thecsw/gana
 
-go 1.19
+go 1.18
 
 require golang.org/x/exp v0.0.0-20221110155412-d0897a79cd37

--- a/ops.go
+++ b/ops.go
@@ -1,4 +1,4 @@
-package echidna
+package gana
 
 import "golang.org/x/exp/constraints"
 

--- a/workers.go
+++ b/workers.go
@@ -1,4 +1,4 @@
-package echidna
+package gana
 
 import "sync"
 


### PR DESCRIPTION
The repository name was updated from `echidna` to `gana`, but the actual package name wasn't. This PR fixes it.

We are not using any features from go1.19, only the go1.18 syntax. If it's disputed, we can change it back. 

Thank you.

Signed-off-by: Sandy <sandy@sandyuraz.com>