### PR TITLE
Better actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.18
 
       - name: Install moreutils
-        run: apt install -y moreutils
+        run: sudo apt install -y moreutils
           
       - name: Gofmt
         run: not gofmt -l . | grep .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,28 +29,12 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v -json ./... > TestResults-${{ matrix.go-version }}.json
+        run: go test -race -covermode atomic -coverprofile=covprofile ./...
 
-      - name: Upload Go test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: Go-tests-${{ matrix.go-version }}
-          path: TestResults-${{ matrix.go-version }}.json
-        
-      - name: Install cover
-        run: go install golang.org/x/tools/cmd/cover@latest
+      - name: Install goveralls
+        run: go install github.com/mattn/goveralls@latest
 
-      - name: Run cover
-        run: go test -coverprofile=c.out
-        
-      - name: Diplay cover
-        run: go tool cover -func=c.out
-
-      - name: Generate html cover
-        run: go tool cover -html=c.out -o Coverage-${{ matrix.go-version }}.html
-
-      - name: Upload Go cover results
-        uses: actions/upload-artifact@v3
-        with:
-          name: Go-cover-${{ matrix.go-version }}
-          path: Coverage-${{ matrix.go-version }}.html
+      - name: Send coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALL_TOKEN }}
+        run: goveralls -coverprofile=covprofile -service=github

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,24 +2,42 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
-
-  build:
+  
+  setup:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.18
+  gofmt:
+    needs: setup
+    steps:
+      - name: Gofmt
+        run: not gofmt -l . | grep .
 
-    - name: Build
-      run: go build -v ./...
+  build:
+    needs: setup
+    steps:
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+  test:
+    needs: build
+    steps:
+      - name: Test
+        run: go test -v ./...
+
+  cover:
+    needs: build
+    steps:
+      - name: Install cover
+        run: go install golang.org/x/tools/cmd/cover@latest
+      - name: cover
+        run: go tool cover -func=c.out

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,13 +8,16 @@ jobs:
   
   Go:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.18', '1.19' ]
     steps:
       - uses: actions/checkout@v3
         
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.go-version }}
 
       - name: Install moreutils
         run: sudo apt install -y moreutils
@@ -22,14 +25,35 @@ jobs:
       - name: Gofmt
         run: if [[ $(gofmt -l . | head -c1 | wc -c) -ne 0 ]]; then false; fi
 
+      - name: Get
+        run: go get -v ./...
+        
       - name: Build
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go test -v -json ./... > TestResults-${{ matrix.go-version }}.json
 
+      - name: Upload Go test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: Go-tests-${{ matrix.go-version }}
+          path: TestResults-${{ matrix.go-version }}.json
+        
       - name: Install cover
         run: go install golang.org/x/tools/cmd/cover@latest
+
+      - name: Run cover
+        run: go test -coverprofile=c.out
         
-      - name: cover
+      - name: Diplay cover
         run: go tool cover -func=c.out
+
+      - name: Generate html cover
+        run: go tool cover -html=c.out -o Coverage-${{ matrix.go-version }}.html
+
+      - name: Upload Go cover results
+        uses: actions/upload-artifact@v3
+        with:
+          name: Go-cover-${{ matrix.go-version }}
+          path: Coverage-${{ matrix.go-version }}.html

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   
-  setup:
+  Go:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,32 +16,20 @@ jobs:
         with:
           go-version: 1.18
 
-  gofmt:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
+      - name: Install moreutils
+        run: apt get -y moreutils
+          
       - name: Gofmt
         run: not gofmt -l . | grep .
 
-  build:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
       - name: Build
         run: go build -v ./...
 
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Test
         run: go test -v ./...
 
-  cover:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Install cover
         run: go install golang.org/x/tools/cmd/cover@latest
+        
       - name: cover
         run: go tool cover -func=c.out

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt install -y moreutils
           
       - name: Gofmt
-        run: not gofmt -l . | grep .
+        run: if [[ $(gofmt -l . | head -c1 | wc -c) -ne 0 ]]; then false; fi
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,5 +36,5 @@ jobs:
 
       - name: Send coverage
         env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALL_TOKEN }}
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=covprofile -service=github

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Install moreutils
-        run: sudo apt install -y moreutils
-          
       - name: Gofmt
         run: if [[ $(gofmt -l . | head -c1 | wc -c) -ne 0 ]]; then false; fi
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.18
 
       - name: Install moreutils
-        run: apt get -y moreutils
+        run: apt install -y moreutils
           
       - name: Gofmt
         run: not gofmt -l . | grep .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,24 +17,28 @@ jobs:
           go-version: 1.18
 
   gofmt:
+    runs-on: ubuntu-latest
     needs: setup
     steps:
       - name: Gofmt
         run: not gofmt -l . | grep .
 
   build:
+    runs-on: ubuntu-latest
     needs: setup
     steps:
       - name: Build
         run: go build -v ./...
 
   test:
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Test
         run: go test -v ./...
 
   cover:
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Install cover

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -race -covermode atomic -coverprofile=covprofile ./...
+        run: go test -race -covermode atomic -coverprofile=covprofile-${{ matrix.go-version }} ./...
 
       - name: Install goveralls
         run: go install github.com/mattn/goveralls@latest
@@ -37,4 +37,4 @@ jobs:
       - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: goveralls -coverprofile=covprofile -service=github
+        run: goveralls -coverprofile=covprofile-${{ matrix.go-version }} -service=github


### PR DESCRIPTION
This update to actions will run matrix (parallel) jobs for go 1.18 and go 1.19 with:

- Fail if code is not properly formatted with `gofmt`
- Run tests and publish artifacts
- Run cover tests and publish html output

The artifacts (.html and .json) files of tests can be found at the bottom of the action's Summary page.