### PR TITLE
Add vararg Min and Max functions

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -48,6 +48,25 @@ func Maxv[T constraints.Ordered](vals ...T) T {
 	return max
 }
 
+// MinMaxv returns the minimum and maximum of the given values, or if no values are given, two zero value of the type.
+func MinMaxv[T constraints.Ordered](vals ...T) (T, T) {
+	if len(vals) == 0 {
+		return ZeroValue[T](), ZeroValue[T]()
+	}
+
+	min := vals[0]
+	max := vals[0]
+	for _, v := range vals {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return min, max
+}
+
 // First returns the first element of the given array, zero value otherwise.
 func First[T any](x []T) T {
 	if len(x) == 0 {

--- a/ops.go
+++ b/ops.go
@@ -18,6 +18,36 @@ func Max[T constraints.Ordered](a, b T) T {
 	return b
 }
 
+// Minv returns the minimum of the given values, or if no values are given, the zero value of the type.
+func Minv[T constraints.Ordered](vals ...T) T {
+	if len(vals) == 0 {
+		return ZeroValue[T]()
+	}
+
+	min := vals[0]
+	for _, v := range vals {
+		if v < min {
+			min = v
+		}
+	}
+	return min
+}
+
+// Maxv returns the maximum of the given values, or if no values are given, the zero value of the type.
+func Maxv[T constraints.Ordered](vals ...T) T {
+	if len(vals) == 0 {
+		return ZeroValue[T]()
+	}
+
+	max := vals[0]
+	for _, v := range vals {
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
 // First returns the first element of the given array, zero value otherwise.
 func First[T any](x []T) T {
 	if len(x) == 0 {

--- a/ops_test.go
+++ b/ops_test.go
@@ -30,6 +30,30 @@ func TestMax(t *testing.T) {
 	assert.Equal(t, Max("a", "a"), "a", "a, a")
 }
 
+func TestMinv(t *testing.T) {
+	assert.Equal(t, Minv(1, 2, 3), 1, "1, 2, 3")
+	assert.Equal(t, Minv(2, 1, 3), 1, "2, 1, 3")
+	assert.Equal(t, Minv(3, 2, 1), 1, "3, 2, 1")
+	assert.Equal(t, Minv(1.0, 2.0, 3.0), 1.0, "1.0, 2.0, 3.0")
+	assert.Equal(t, Minv(2.0, 1.0, 3.0), 1.0, "2.0, 1.0, 3.0")
+	assert.Equal(t, Minv(3.0, 2.0, 1.0), 1.0, "3.0, 2.0, 1.0")
+	assert.Equal(t, Minv("a", "b", "c"), "a", `"a", "b", "c"`)
+	assert.Equal(t, Minv("b", "a", "c"), "a", `"b", "a", "c"`)
+	assert.Equal(t, Minv("c", "b", "a"), "a", `"c", "b", "a"`)
+}
+
+func TestMaxv(t *testing.T) {
+	assert.Equal(t, Maxv(1, 2, 3), 3, "1, 2, 3")
+	assert.Equal(t, Maxv(2, 1, 3), 3, "2, 1, 3")
+	assert.Equal(t, Maxv(3, 2, 1), 3, "3, 2, 1")
+	assert.Equal(t, Maxv(1.0, 2.0, 3.0), 3.0, "1.0, 2.0, 3.0")
+	assert.Equal(t, Maxv(2.0, 1.0, 3.0), 3.0, "2.0, 1.0, 3.0")
+	assert.Equal(t, Maxv(3.0, 2.0, 1.0), 3.0, "3.0, 2.0, 1.0")
+	assert.Equal(t, Maxv("a", "b", "c"), "c", `"a", "b", "c"`)
+	assert.Equal(t, Maxv("b", "a", "c"), "c", `"b", "a", "c"`)
+	assert.Equal(t, Maxv("c", "b", "a"), "c", `"c", "b", "a"`)
+}
+
 func TestFirst(t *testing.T) {
 	assert.Equal(t, First([]int{1, 2, 3}), 1, "1, 2, 3")
 	assert.Equal(t, First([]int{}), 0, "[]int{}")

--- a/ops_test.go
+++ b/ops_test.go
@@ -54,6 +54,36 @@ func TestMaxv(t *testing.T) {
 	assert.Equal(t, Maxv("c", "b", "a"), "c", `"c", "b", "a"`)
 }
 
+func TestMinMaxv(t *testing.T) {
+	a, b := MinMaxv(1, 2, 3)
+	assert.Equal(t, a, 1, "1, 2, 3")
+	assert.Equal(t, b, 3, "1, 2, 3")
+	a, b = MinMaxv(2, 1, 3)
+	assert.Equal(t, a, 1, "2, 1, 3")
+	assert.Equal(t, b, 3, "2, 1, 3")
+	a, b = MinMaxv(3, 2, 1)
+	assert.Equal(t, a, 1, "3, 2, 1")
+	assert.Equal(t, b, 3, "3, 2, 1")
+	c, d := MinMaxv(1.0, 2.0, 3.0)
+	assert.Equal(t, c, 1.0, "1.0, 2.0, 3.0")
+	assert.Equal(t, d, 3.0, "1.0, 2.0, 3.0")
+	c, d = MinMaxv(2.0, 1.0, 3.0)
+	assert.Equal(t, c, 1.0, "2.0, 1.0, 3.0")
+	assert.Equal(t, d, 3.0, "2.0, 1.0, 3.0")
+	c, d = MinMaxv(3.0, 2.0, 1.0)
+	assert.Equal(t, c, 1.0, "3.0, 2.0, 1.0")
+	assert.Equal(t, d, 3.0, "3.0, 2.0, 1.0")
+	e, f := MinMaxv("a", "b", "c")
+	assert.Equal(t, e, "a", `"a", "b", "c"`)
+	assert.Equal(t, f, "c", `"a", "b", "c"`)
+	e, f = MinMaxv("b", "a", "c")
+	assert.Equal(t, e, "a", `"b", "a", "c"`)
+	assert.Equal(t, f, "c", `"b", "a", "c"`)
+	e, f = MinMaxv("c", "b", "a")
+	assert.Equal(t, e, "a", `"c", "b", "a"`)
+	assert.Equal(t, f, "c", `"c", "b", "a"`)
+}
+
 func TestFirst(t *testing.T) {
 	assert.Equal(t, First([]int{1, 2, 3}), 1, "1, 2, 3")
 	assert.Equal(t, First([]int{}), 0, "[]int{}")


### PR DESCRIPTION
Add the `Minv`, `Maxv` and `MinMaxv` functions that return the minimum, maximum, and both, of the args, respectively.