### PR TITLE
Added tests for generic workers

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -2,9 +2,10 @@ package gana
 
 import "sync"
 
-// GenericWorkers spins up given number of genericWorker routines
-// that all perform work and it itself returns the outputs channel
-// with the buffer defined by cz.
+// GenericWorkers spins up given number of `genericWorker` routines
+// that all perform `work` and it itself returns the `outputs` channel
+// with the buffer defined by `cz`; do close the `inputs` channel when
+// there is no more work left for workers to safely exit their goroutines.
 func GenericWorkers[A, B any](
 	inputs <-chan A,
 	work func(A) B,
@@ -24,9 +25,10 @@ func GenericWorkers[A, B any](
 	return outputs
 }
 
-// GenericWorker gets values from inputs channel, performs work
-// on the value and puts it into the outputs channel, while also
-// marking itself as Done in WaitGroup when channel is closed.
+// GenericWorker gets values from `inputs channel`, performs `work`
+// on the value and puts it into the `outputs` channel, while also
+// marking itself as `Done` in `WaitGroup` when `inputs` channel
+// is closed.
 func GenericWorker[A, B any](
 	inputs <-chan A,
 	outputs chan<- B,

--- a/workers_test.go
+++ b/workers_test.go
@@ -1,0 +1,72 @@
+package gana
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenericWorker(t *testing.T) {
+	inputs := make(chan int)
+	outputs := make(chan string)
+	wg := &sync.WaitGroup{}
+	sq := func(a int) string {
+		return strconv.Itoa(a * a)
+	}
+	go GenericWorker(inputs, outputs, sq, wg)
+	wg.Add(1)
+	for i := -1000; i <= 1000; i++ {
+		inputs <- i
+		assert.Equal(t, sq(i), <-outputs,
+			fmt.Sprintf("worker [%d]", i))
+	}
+	close(inputs)
+	close(outputs)
+	wg.Wait()
+}
+
+func TestGenericWorkers(t *testing.T) {
+	inputs := make(chan int)
+	sq := func(a int) int {
+		return a * a
+	}
+	double := func(a int) int {
+		return a + a
+	}
+	sub5 := func(a int) int {
+		return a - 5
+	}
+	strc := func(a int) string {
+		return strconv.Itoa(a)
+	}
+	toint := func(a string) int {
+		f, err := strconv.ParseInt(a, 10, 64)
+		assert.Nil(t, err, fmt.Sprintf("parse float of %s", a))
+		return int(f)
+	}
+	squares := GenericWorkers(inputs, sq, 10, 20)
+	doubles := GenericWorkers(squares, double, 20, 40)
+	sub5s := GenericWorkers(doubles, sub5, 40, 60)
+	strcs := GenericWorkers(sub5s, strc, 60, 5)
+	ints := GenericWorkers(strcs, toint, 5, 1)
+
+	results := make([]int, 0, 1001)
+	go func() {
+		for i := 0; i <= 1000; i++ {
+			inputs <- i
+		}
+		close(inputs)
+	}()
+	for ii := range ints {
+		results = append(results, ii)
+	}
+	sort.Ints(results)
+	for i := 0; i <= 1000; i++ {
+		assert.Equal(t, toint(strc(sub5(double(sq(i))))), results[i],
+			fmt.Sprintf("Checking value %d", i))
+	}
+}

--- a/workers_test.go
+++ b/workers_test.go
@@ -45,7 +45,7 @@ func TestGenericWorkers(t *testing.T) {
 	}
 	toint := func(a string) int {
 		f, err := strconv.ParseInt(a, 10, 64)
-		assert.Nil(t, err, fmt.Sprintf("parse float of %s", a))
+		assert.Nil(t, err, fmt.Sprintf("parse int of %s", a))
 		return int(f)
 	}
 	squares := GenericWorkers(inputs, sq, 10, 20)


### PR DESCRIPTION
Added tests for generic workers by chaining workers together and giving them unique work, where we also see if all the expected outputs match as well.

Signed-off-by: Sandy <sandy@sandyuraz.com>